### PR TITLE
dev 환경에서 secure false로 작동하도록 변경

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/properties/CookieProperties.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/properties/CookieProperties.java
@@ -1,0 +1,9 @@
+package shop.sgmarket.sgmarketbackend.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt.cookie")
+public record CookieProperties(
+        boolean isSecure
+) {
+}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
@@ -1,13 +1,14 @@
 package shop.sgmarket.sgmarketbackend.global.util;
 
-import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.REFRESH_TOKEN_COOKIE_NAME;
 import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.ACCESS_TOKEN_COOKIE_NAME;
+import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.REFRESH_TOKEN_COOKIE_NAME;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import shop.sgmarket.sgmarketbackend.global.properties.CookieProperties;
 import shop.sgmarket.sgmarketbackend.global.properties.JwtProperties;
 
 @Component
@@ -15,6 +16,7 @@ import shop.sgmarket.sgmarketbackend.global.properties.JwtProperties;
 public class CookieUtil {
 
     private final JwtProperties jwtProperties;
+    private final CookieProperties cookieProperties;
 
     public HttpHeaders generateTokenCookies(final String accessToken, final String refreshToken) {
         String sameSite = determineSameSitePolicy();
@@ -22,7 +24,7 @@ public class CookieUtil {
         ResponseCookie accessTokenCookie =
                 ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
                         .path("/")
-                        .secure(true)
+                        .secure(cookieProperties.isSecure())
                         .sameSite(sameSite)
                         .httpOnly(true)
                         .maxAge(jwtProperties.accessTokenExpirationTime())
@@ -31,7 +33,7 @@ public class CookieUtil {
         ResponseCookie refreshTokenCookie =
                 ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
                         .path("/")
-                        .secure(true)
+                        .secure(cookieProperties.isSecure())
                         .sameSite(sameSite)
                         .httpOnly(true)
                         .maxAge(jwtProperties.refreshTokenExpirationTime())

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,3 +16,7 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
+
+jwt:
+  cookie:
+    is-secure: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,3 +16,7 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
+
+jwt:
+  cookie:
+    is-secure: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,3 +16,7 @@ logging:
   level:
     org.hibernate.SQL: info
     org.hibernate.type: warn
+
+jwt:
+  cookie:
+    is-secure: true


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #17

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 프론트 로컬에서 쿠키 저장이 안되므로 dev환경에서는 secure 옵션을 false로 동작하도록 수정했습니다.
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced adjustable JWT cookie security settings that automatically align with each deployment environment (development, local, production) to enhance authentication safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->