### PR TITLE
로그인 후 프론트엔드 도메인으로 리다이렉트 되도록 변경

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthController.java
@@ -1,6 +1,7 @@
 package shop.sgmarket.sgmarketbackend.auth.api;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,22 +11,22 @@ import shop.sgmarket.sgmarketbackend.auth.application.AuthService;
 import shop.sgmarket.sgmarketbackend.auth.domain.OAuthProvider;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.OAuthTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.SocialClientResponse;
-import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
+import shop.sgmarket.sgmarketbackend.global.properties.RedirectUriProperties;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController implements AuthDocs {
 
+    private final RedirectUriProperties redirectUriProperties;
     private final AuthService authService;
 
-    @Override
     @GetMapping("/login")
-    public ApiResponseTemplate<Void> socialLogin(
+    public void socialLogin(
             @RequestParam final String provider,
             @RequestParam final String code,
             HttpServletResponse response
-    ) {
+    ) throws IOException {
         OAuthProvider oauthProvider = OAuthProvider.from(provider);
         OAuthTokenResponse oAuthTokenResponse = authService.getToken(oauthProvider, code);
         SocialClientResponse socialClientResponse = authService.authenticateFromProvider(oauthProvider,
@@ -39,8 +40,10 @@ public class AuthController implements AuthDocs {
                 socialClientResponse.profileImage(),
                 response
         );
-        return ApiResponseTemplate.ok();
+
+        response.sendRedirect(redirectUriProperties.redirectUri());
     }
+
 
     // TODO: 로그아웃 API 구현
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthDocs.java
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.AuthTokenResponse;
-import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
 
 @Tag(name = "[인증 API]", description = "인증 관련 API")
 public interface AuthDocs {
@@ -20,9 +20,9 @@ public interface AuthDocs {
                     @ApiResponse(responseCode = "400", description = "잘못된 요청"),
                     @ApiResponse(responseCode = "500", description = "서버 오류")
             })
-    ApiResponseTemplate<Void> socialLogin(
+    void socialLogin (
             @Parameter(description = "소셜 제공자", required = true) String provider,
             @Parameter(description = "인증 코드", required = true) String code,
             HttpServletResponse response
-    );
+    ) throws IOException;
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/properties/RedirectUriProperties.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/properties/RedirectUriProperties.java
@@ -2,8 +2,8 @@ package shop.sgmarket.sgmarketbackend.global.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "jwt.cookie")
-public record CookieProperties(
-        boolean isSecure
+@ConfigurationProperties(prefix = "frontend")
+public record RedirectUriProperties(
+        String redirectUri
 ) {
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
@@ -8,7 +8,6 @@ import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
-import shop.sgmarket.sgmarketbackend.global.properties.CookieProperties;
 import shop.sgmarket.sgmarketbackend.global.properties.JwtProperties;
 
 @Component
@@ -16,7 +15,6 @@ import shop.sgmarket.sgmarketbackend.global.properties.JwtProperties;
 public class CookieUtil {
 
     private final JwtProperties jwtProperties;
-    private final CookieProperties cookieProperties;
 
     public HttpHeaders generateTokenCookies(final String accessToken, final String refreshToken) {
         String sameSite = determineSameSitePolicy();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,6 +17,5 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
 
-jwt:
-  cookie:
-    is-secure: false
+frontend:
+  redirect-uri: ${REDIRECT_URI}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,6 +17,5 @@ logging:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
 
-jwt:
-  cookie:
-    is-secure: false
+frontend:
+  redirect-uri: http://localhost:8080/swagger-ui/index.html#/

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,5 @@ logging:
     org.hibernate.SQL: info
     org.hibernate.type: warn
 
-jwt:
-  cookie:
-    is-secure: true
+frontend:
+  redirect-uri: ${REDIRECT_URI}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #<!-- 번호 -->

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 로그인 후 프론트엔드 도메인으로 리다이렉트 되도록 변경하였습니다.
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Social login now redirects users to a specified URI after successful authentication instead of returning a JSON response.

- **Configuration**
  - Added new configuration property for frontend redirect URI.
  - Removed previous JWT cookie security configuration.

- **Bug Fixes**
  - Improved handling of social login responses for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->