### PR TITLE
액세스 토큰 발급 api 추가

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthController.java
@@ -1,14 +1,17 @@
 package shop.sgmarket.sgmarketbackend.auth.api;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import shop.sgmarket.sgmarketbackend.auth.application.AuthService;
 import shop.sgmarket.sgmarketbackend.auth.domain.OAuthProvider;
+import shop.sgmarket.sgmarketbackend.auth.dto.response.AccessTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.OAuthTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.SocialClientResponse;
 
@@ -41,5 +44,8 @@ public class AuthController implements AuthDocs {
         );
     }
 
-    // TODO: 로그아웃 API 구현
+    @PostMapping("/access-token")
+    public AccessTokenResponse reissueAccessToken(HttpServletRequest request) {
+        return authService.getAccessToken(request);
+    }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/api/AuthDocs.java
@@ -1,18 +1,23 @@
 package shop.sgmarket.sgmarketbackend.auth.api;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.springframework.web.bind.annotation.PostMapping;
+import shop.sgmarket.sgmarketbackend.auth.dto.response.AccessTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.AuthTokenResponse;
 
 @Tag(name = "[인증 API]", description = "인증 관련 API")
 public interface AuthDocs {
 
+    @Hidden
     @Operation(summary = "소셜 로그인", description = "소셜 제공자와 인증 코드를 사용하여 로그인을 진행합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "소셜 로그인 성공",
@@ -25,4 +30,14 @@ public interface AuthDocs {
             @Parameter(description = "인증 코드", required = true) String code,
             HttpServletResponse response
     ) throws IOException;
+
+    @PostMapping("/access-token")
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 통해 새로운 액세스 토큰을 발급합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "재발급 성공",
+                            content = @Content(schema = @Schema(implementation = AccessTokenResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "리프레시 토큰이 유효하지 않음"),
+                    @ApiResponse(responseCode = "500", description = "서버 오류")
+            })
+    AccessTokenResponse reissueAccessToken(HttpServletRequest request);
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
@@ -71,7 +71,6 @@ public class AuthService {
     @Transactional
     public AccessTokenResponse getAccessToken(HttpServletRequest request) {
         String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
-        System.out.println("refreshToken = " + refreshToken);
         if (refreshToken == null) {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
@@ -80,7 +80,7 @@ public class AuthService {
         return oauthMember;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public AccessTokenResponse getAccessToken(HttpServletRequest request) {
         String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
         RefreshTokenDto refreshTokenDto = jwtTokenProvider.retrieveRefreshToken(refreshToken);

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
@@ -68,21 +68,6 @@ public class AuthService {
         jwtTokenProvider.generateRefreshToken(member.getId(), member.getRole(), response);
     }
 
-    @Transactional
-    public AccessTokenResponse getAccessToken(HttpServletRequest request) {
-        String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
-        if (refreshToken == null) {
-            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
-        }
-
-        RefreshTokenDto refreshTokenDto = jwtTokenProvider.retrieveRefreshToken(refreshToken);
-        if (refreshTokenDto == null) {
-            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
-        }
-
-        return jwtTokenProvider.generateAccessToken(refreshTokenDto.memberId(), refreshTokenDto.memberRole());
-    }
-
     private Member createOauthMember(final OAuthProvider oAuthProvider,
                                      final String oauthId,
                                      final String email,
@@ -95,5 +80,11 @@ public class AuthService {
         return oauthMember;
     }
 
+    @Transactional
+    public AccessTokenResponse getAccessToken(HttpServletRequest request) {
+        String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
+        RefreshTokenDto refreshTokenDto = jwtTokenProvider.retrieveRefreshToken(refreshToken);
 
+        return jwtTokenProvider.generateAccessToken(refreshTokenDto.memberId(), refreshTokenDto.memberRole());
+    }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
@@ -1,5 +1,6 @@
 package shop.sgmarket.sgmarketbackend.auth.application;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
@@ -8,14 +9,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sgmarket.sgmarketbackend.auth.domain.OAuthProvider;
+import shop.sgmarket.sgmarketbackend.auth.dto.RefreshTokenDto;
+import shop.sgmarket.sgmarketbackend.auth.dto.response.AccessTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.OAuthTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.SocialClientResponse;
 import shop.sgmarket.sgmarketbackend.global.error.ErrorCode;
 import shop.sgmarket.sgmarketbackend.global.error.exception.CustomException;
 import shop.sgmarket.sgmarketbackend.global.properties.RedirectUriProperties;
 import shop.sgmarket.sgmarketbackend.global.security.JwtTokenProvider;
+import shop.sgmarket.sgmarketbackend.global.util.CookieUtil;
 import shop.sgmarket.sgmarketbackend.member.domain.Member;
-import shop.sgmarket.sgmarketbackend.member.domain.MemberRole;
 import shop.sgmarket.sgmarketbackend.member.repository.MemberRepository;
 
 @Slf4j
@@ -61,6 +64,26 @@ public class AuthService {
         response.sendRedirect(redirectUriProperties.redirectUri());
     }
 
+    private void getLoginResponse(final Member member, HttpServletResponse response) {
+        jwtTokenProvider.generateRefreshToken(member.getId(), member.getRole(), response);
+    }
+
+    @Transactional
+    public AccessTokenResponse getAccessToken(HttpServletRequest request) {
+        String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
+        System.out.println("refreshToken = " + refreshToken);
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        RefreshTokenDto refreshTokenDto = jwtTokenProvider.retrieveRefreshToken(refreshToken);
+        if (refreshTokenDto == null) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        return jwtTokenProvider.generateAccessToken(refreshTokenDto.memberId(), refreshTokenDto.memberRole());
+    }
+
     private Member createOauthMember(final OAuthProvider oAuthProvider,
                                      final String oauthId,
                                      final String email,
@@ -73,7 +96,5 @@ public class AuthService {
         return oauthMember;
     }
 
-    private void getLoginResponse(final Member member, HttpServletResponse response) {
-        jwtTokenProvider.generateTokenPair(member.getId(), MemberRole.USER, response);
-    }
+
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/dto/RefreshTokenDto.java
@@ -1,7 +1,10 @@
 package shop.sgmarket.sgmarketbackend.auth.dto;
 
+import shop.sgmarket.sgmarketbackend.member.domain.MemberRole;
+
 public record RefreshTokenDto(
         Long memberId,
+        MemberRole memberRole,
         String tokenValue,
         Long ttl
 ) {

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,9 @@
+package shop.sgmarket.sgmarketbackend.auth.dto.response;
+
+public record AccessTokenResponse(
+        String accessToken
+) {
+    public static AccessTokenResponse of(final String accessToken) {
+        return new AccessTokenResponse(accessToken);
+    }
+}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     // 401 UNAUTHORIZED
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "AUTH_4011", "인증이 필요합니다."),
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "AUTH_4012", "작성자가 아닙니다"),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"AUTH_4013", "리프레시 토큰이 유효하지 않습니다."),
 
     // 403 FORBIDDEN
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "AUTH_4031", "접근 권한이 없습니다."),
@@ -27,6 +28,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4041", "회원을 찾을 수 없습니다."),
     AUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "AUCTION_4041", "경매를 찾을 수 없습니다."),
     AUCTION_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "AUCTION_4042", "경매 카테고리를 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_4041", "리프레시 토큰을 찾을 수 없습니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYSTEM_5001", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/filter/JwtAuthenticationFilter.java
@@ -1,12 +1,9 @@
 package shop.sgmarket.sgmarketbackend.global.filter;
 
-import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.ACCESS_TOKEN_COOKIE_NAME;
-import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.REFRESH_TOKEN_COOKIE_NAME;
 import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.TOKEN_PREFIX;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -20,11 +17,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.util.WebUtils;
 import shop.sgmarket.sgmarketbackend.auth.dto.AccessTokenDto;
 import shop.sgmarket.sgmarketbackend.auth.dto.RefreshTokenDto;
 import shop.sgmarket.sgmarketbackend.global.security.JwtTokenProvider;
 import shop.sgmarket.sgmarketbackend.global.security.PrincipalDetails;
+import shop.sgmarket.sgmarketbackend.global.util.CookieUtil;
 import shop.sgmarket.sgmarketbackend.member.domain.MemberRole;
 
 @Slf4j
@@ -40,8 +37,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 1. 쿠키 Access Token 가져오기
-        String accessToken = extractAccessTokenFromCookie(request);
+        // 1. 헤더에서 Access Token 가져오기
+        String accessToken = extractAccessTokenFromHeader(request);
 
         if (accessToken != null) {
             AccessTokenDto accessTokenDto = jwtTokenProvider.retrieveAccessToken(accessToken);
@@ -53,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         // 2. 쿠키에서 Refresh Token 가져오기
-        String refreshToken = extractRefreshTokenFromCookie(request);
+        String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
         if (refreshToken == null) {
             filterChain.doFilter(request, response);
             return;
@@ -83,15 +80,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    private String extractAccessTokenFromCookie(HttpServletRequest request) {
-        return Optional.ofNullable(WebUtils.getCookie(request, ACCESS_TOKEN_COOKIE_NAME))
-                .map(Cookie::getValue)
-                .orElse(null);
-    }
-
-    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        return Optional.ofNullable(WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME))
-                .map(Cookie::getValue)
+    private static String extractAccessTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+                .filter(header -> header.startsWith(TOKEN_PREFIX))
+                .map(header -> header.replace(TOKEN_PREFIX, ""))
                 .orElse(null);
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/security/JwtTokenProvider.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/security/JwtTokenProvider.java
@@ -14,6 +14,8 @@ import shop.sgmarket.sgmarketbackend.auth.dto.AccessTokenDto;
 import shop.sgmarket.sgmarketbackend.auth.dto.RefreshTokenDto;
 import shop.sgmarket.sgmarketbackend.auth.dto.response.AccessTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.repository.RefreshTokenRepository;
+import shop.sgmarket.sgmarketbackend.global.error.ErrorCode;
+import shop.sgmarket.sgmarketbackend.global.error.exception.CustomException;
 import shop.sgmarket.sgmarketbackend.global.util.CookieUtil;
 import shop.sgmarket.sgmarketbackend.global.util.JwtUtil;
 import shop.sgmarket.sgmarketbackend.member.domain.MemberRole;
@@ -80,19 +82,18 @@ public class JwtTokenProvider {
 
     public RefreshTokenDto retrieveRefreshToken(final String refreshTokenValue) {
         RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
-
         if (refreshTokenDto == null) {
-            return null;
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         Optional<RefreshToken> refreshToken = getRefreshTokenFromRedis(refreshTokenDto.memberId());
-
-        if (refreshToken.isPresent()) {
-            return refreshTokenDto;
+        if (refreshToken.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        return null;
+        return refreshTokenDto;
     }
+
 
     private Optional<RefreshToken> getRefreshTokenFromRedis(final Long memberId) {
         return refreshTokenRepository.findById(memberId);

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/security/JwtTokenProvider.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/security/JwtTokenProvider.java
@@ -4,7 +4,6 @@ import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.TOK
 
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +12,7 @@ import org.springframework.stereotype.Service;
 import shop.sgmarket.sgmarketbackend.auth.domain.RefreshToken;
 import shop.sgmarket.sgmarketbackend.auth.dto.AccessTokenDto;
 import shop.sgmarket.sgmarketbackend.auth.dto.RefreshTokenDto;
+import shop.sgmarket.sgmarketbackend.auth.dto.response.AccessTokenResponse;
 import shop.sgmarket.sgmarketbackend.auth.repository.RefreshTokenRepository;
 import shop.sgmarket.sgmarketbackend.global.util.CookieUtil;
 import shop.sgmarket.sgmarketbackend.global.util.JwtUtil;
@@ -27,16 +27,21 @@ public class JwtTokenProvider {
     private final CookieUtil cookieUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public void generateTokenPair(final Long memberId,
-                                  final MemberRole memberRole,
-                                  HttpServletResponse response) {
-        String accessToken = createAccessToken(memberId, memberRole);
-        String refreshToken = createRefreshToken(memberId);
+    public void generateRefreshToken(final Long memberId,
+                                        final MemberRole memberRole,
+                                     HttpServletResponse response) {
+        String refreshToken = createRefreshToken(memberId, memberRole);
 
-        HttpHeaders cookieHeaders = cookieUtil.generateTokenCookies(accessToken, refreshToken);
-        for (String cookie : Objects.requireNonNull(cookieHeaders.get(HttpHeaders.SET_COOKIE))) {
-            response.addHeader(HttpHeaders.SET_COOKIE, cookie);
-        }
+        HttpHeaders cookieHeaders = cookieUtil.generateTokenCookies(refreshToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieHeaders.getFirst(HttpHeaders.SET_COOKIE));
+
+    }
+
+    public AccessTokenResponse generateAccessToken(final Long memberId,
+                                                   final MemberRole memberRole) {
+        String accessToken = createAccessToken(memberId, memberRole);
+
+        return AccessTokenResponse.of(accessToken);
     }
 
 
@@ -48,8 +53,8 @@ public class JwtTokenProvider {
         return jwtUtil.generateAccessTokenDto(memberId, memberRole);
     }
 
-    private String createRefreshToken(final Long memberId) {
-        String refreshTokenValue = jwtUtil.generateRefreshToken(memberId);
+    private String createRefreshToken(final Long memberId, final MemberRole memberRole) {
+        String refreshTokenValue = jwtUtil.generateRefreshToken(memberId, memberRole);
         saveRefreshTokenToRedis(memberId, refreshTokenValue, jwtUtil.getRefreshTokenExpirationTime());
         return refreshTokenValue;
     }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
@@ -4,13 +4,14 @@ import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.REF
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.WebUtils;
+import shop.sgmarket.sgmarketbackend.global.error.ErrorCode;
+import shop.sgmarket.sgmarketbackend.global.error.exception.CustomException;
 import shop.sgmarket.sgmarketbackend.global.properties.JwtProperties;
 
 @Component
@@ -42,8 +43,10 @@ public class CookieUtil {
     }
 
     public static String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        return Optional.ofNullable(WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME))
-                .map(Cookie::getValue)
-                .orElse(null);
+        Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME);
+        if (cookie == null || cookie.getValue() == null) {
+            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+        return cookie.getValue();
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
@@ -1,13 +1,16 @@
 package shop.sgmarket.sgmarketbackend.global.util;
 
-import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.ACCESS_TOKEN_COOKIE_NAME;
 import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.REFRESH_TOKEN_COOKIE_NAME;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
 import shop.sgmarket.sgmarketbackend.global.properties.JwtProperties;
 
 @Component
@@ -16,17 +19,8 @@ public class CookieUtil {
 
     private final JwtProperties jwtProperties;
 
-    public HttpHeaders generateTokenCookies(final String accessToken, final String refreshToken) {
+    public HttpHeaders generateTokenCookies(final String refreshToken) {
         String sameSite = determineSameSitePolicy();
-
-        ResponseCookie accessTokenCookie =
-                ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessToken)
-                        .path("/")
-                        .secure(true)
-                        .sameSite(sameSite)
-                        .httpOnly(true)
-                        .maxAge(jwtProperties.accessTokenExpirationTime())
-                        .build();
 
         ResponseCookie refreshTokenCookie =
                 ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
@@ -38,7 +32,6 @@ public class CookieUtil {
                         .build();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
         headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         return headers;
@@ -46,5 +39,11 @@ public class CookieUtil {
 
     private String determineSameSitePolicy() {
         return SameSite.NONE.attributeValue();
+    }
+
+    public static String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        return Optional.ofNullable(WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME))
+                .map(Cookie::getValue)
+                .orElse(null);
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/util/JwtUtil.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/util/JwtUtil.java
@@ -42,10 +42,10 @@ public class JwtUtil {
         return AccessTokenDto.of(memberId, memberRole, tokenValue);
     }
 
-    public String generateRefreshToken(final Long memberId) {
+    public String generateRefreshToken(final Long memberId, final MemberRole memberRole) {
         Date issuedAt = new Date();
         Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
-        return buildRefreshToken(memberId, issuedAt, expiredAt);
+        return buildRefreshToken(memberId, memberRole, issuedAt, expiredAt);
     }
 
     public AccessTokenDto parseAccessToken(final String token) throws ExpiredJwtException {
@@ -69,6 +69,7 @@ public class JwtUtil {
 
             return new RefreshTokenDto(
                     Long.parseLong(claims.getBody().getSubject()),
+                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
                     token,
                     jwtProperties.refreshTokenExpirationTime()
             );
@@ -111,10 +112,12 @@ public class JwtUtil {
                 .compact();
     }
 
-    private String buildRefreshToken(final Long memberId, final Date issuedAt, final Date expiredAt) {
+    private String buildRefreshToken(final Long memberId, MemberRole memberRole, final Date issuedAt,
+                                     final Date expiredAt) {
         return Jwts.builder()
                 .setHeader(createTokenHeader(TokenType.REFRESH))
                 .setSubject(memberId.toString())
+                .claim(TOKEN_ROLE_NAME, memberRole.name())
                 .setIssuedAt(issuedAt)
                 .setExpiration(expiredAt)
                 .signWith(getRefreshTokenKey())


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #30 

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 액세스 토큰 발급 api 추가하였습니다.
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an endpoint for reissuing access tokens using a refresh token.
  - Introduced a dedicated response format for access token issuance.
- **Improvements**
  - Access tokens are now provided via the Authorization header instead of cookies.
  - Refresh tokens now include user role information for enhanced security.
  - Token handling logic separated for clearer access and refresh token management.
- **Bug Fixes**
  - Added new error messages for invalid or missing refresh tokens.
- **Documentation**
  - Updated API documentation to include the new access token reissue endpoint and improved endpoint visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->