### PR TITLE
스웨거 접속 안되는 문제 해결

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auth/application/AuthService.java
@@ -83,8 +83,15 @@ public class AuthService {
     @Transactional(readOnly = true)
     public AccessTokenResponse getAccessToken(HttpServletRequest request) {
         String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
+        validateRefreshToken(refreshToken);
         RefreshTokenDto refreshTokenDto = jwtTokenProvider.retrieveRefreshToken(refreshToken);
 
         return jwtTokenProvider.generateAccessToken(refreshTokenDto.memberId(), refreshTokenDto.memberRole());
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/util/CookieUtil.java
@@ -4,14 +4,13 @@ import static shop.sgmarket.sgmarketbackend.global.constant.SecurityConstant.REF
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.server.Cookie.SameSite;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.WebUtils;
-import shop.sgmarket.sgmarketbackend.global.error.ErrorCode;
-import shop.sgmarket.sgmarketbackend.global.error.exception.CustomException;
 import shop.sgmarket.sgmarketbackend.global.properties.JwtProperties;
 
 @Component
@@ -43,10 +42,8 @@ public class CookieUtil {
     }
 
     public static String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        Cookie cookie = WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME);
-        if (cookie == null || cookie.getValue() == null) {
-            throw new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
-        }
-        return cookie.getValue();
+        return Optional.ofNullable(WebUtils.getCookie(request, REFRESH_TOKEN_COOKIE_NAME))
+                .map(Cookie::getValue)
+                .orElse(null);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #33

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 쿠키에 리프레시 토큰이 없으면 예외가 발생하는 문제를 api 요청할 때만 발생하도록 수정합니다.
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation of refresh tokens during authentication, ensuring that invalid tokens are detected and handled earlier.
- **Refactor**
	- Simplified the process for extracting refresh tokens from cookies, resulting in cleaner and more maintainable code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->