### PR TITLE
precision, scale 속성 제거

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/domain/Auction.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/domain/Auction.java
@@ -50,12 +50,12 @@ public class Auction extends BaseTimeEntity {
     @Column(name = "end_price")
     private long endPrice;
 
-    @Column(nullable = false, precision = 9, scale = 6)
+    @Column(nullable = false)
     @DecimalMin(value = "-90.0")
     @DecimalMax(value = "90.0")
     private Double latitude;
 
-    @Column(nullable = false, precision = 9, scale = 6)
+    @Column(nullable = false)
     @DecimalMin(value = "-180.0")
     @DecimalMax(value = "180.0")
     private Double longitude;

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/domain/MemberLocation.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/domain/MemberLocation.java
@@ -16,12 +16,12 @@ public class MemberLocation {
 
     private String address;
 
-    @Column(nullable = false, precision = 9, scale = 6)
+    @Column(nullable = false)
     @DecimalMin(value = "-90.0")
     @DecimalMax(value = "90.0")
     private Double latitude;
 
-    @Column(nullable = false, precision = 9, scale = 6)
+    @Column(nullable = false)
     @DecimalMin(value = "-180.0")
     @DecimalMax(value = "180.0")
     private Double longitude;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #<!-- 번호 -->

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- Hibernate 6.5부터는 Double, Float, Real 타입에 대해 precision과 scale 설정을 허용하지 않기 때문에 precision, scale 속성 제거합니다
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated database field definitions for latitude and longitude to remove precision and scale settings. Existing validation and required field constraints remain unchanged. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->