### PR TITLE
경매 작성자의 다른 경매 목록 조회 기능 추가

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/AuctionController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/AuctionController.java
@@ -49,6 +49,16 @@ public class AuctionController implements AuctionDocs {
     }
 
     @Override
+    @GetMapping("/{auctionId}/others")
+    public ApiResponseTemplate<SliceResponse<AuctionInfoResponse>> getOtherAuctionsBySameMember(
+            @PathVariable Long auctionId,
+            @ParameterObject Pageable pageable
+    ) {
+        SliceResponse<AuctionInfoResponse> response = auctionService.getOtherAuctionsBySameMember(auctionId, pageable);
+        return ApiResponseTemplate.ok("해당 작성자의 다른 경매 목록 조회에 성공했습니다.", response);
+    }
+
+    @Override
     @GetMapping
     public ApiResponseTemplate<SliceResponse<AuctionInfoResponse>> getAuctionsByAddressAndCategory(
             @RequestParam(value = "category", required = false) String category,

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/AuctionDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/AuctionDocs.java
@@ -44,6 +44,18 @@ public interface AuctionDocs {
             @PathVariable Long auctionId
     );
 
+    @Operation(summary = "해당 작성자의 다른 경매 목록 조회", description = "특정 경매 작성자의 다른 활성 경매 목록을 조회합니다.")
+    ApiResponseTemplate<SliceResponse<AuctionInfoResponse>> getOtherAuctionsBySameMember(
+            @Parameter(description = "조회할 경매 ID", required = true)
+            @PathVariable Long auctionId,
+
+            @Parameter(description = "페이지네이션 정보", required = true)
+            @ParameterObject
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    );
+
+
     @Operation(summary = "주소 및 카테고리 기반 경매 목록 조회", description = "주소와 카테고리 기준으로 경매 목록을 조회합니다.")
     ApiResponseTemplate<SliceResponse<AuctionInfoResponse>> getAuctionsByAddressAndCategory(
             @Parameter(

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/AuctionService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/AuctionService.java
@@ -70,6 +70,21 @@ public class AuctionService {
     }
 
     @Transactional(readOnly = true)
+    public SliceResponse<AuctionInfoResponse> getOtherAuctionsBySameMember(Long auctionId, Pageable pageable) {
+        Auction auction = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_NOT_FOUND));
+        Member author = auction.getMember();
+
+        Slice<Auction> auctions = auctionRepository.findAllByMemberAndStatusAndIdNot(author, Status.ACTIVE, auctionId, pageable);
+
+        Slice<AuctionInfoResponse> auctionInfoResponses = auctions.map(otherAuction ->
+                AuctionInfoResponse.of(otherAuction, otherAuction.getItem(), otherAuction.getMember())
+        );
+
+        return SliceResponse.from(auctionInfoResponses);
+    }
+
+    @Transactional(readOnly = true)
     public SliceResponse<AuctionInfoResponse> getAuctionsByAddressAndCategory(String category, Pageable pageable) {
         Member member = memberUtil.getCurrentMember();
 

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/AuctionService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/AuctionService.java
@@ -71,14 +71,14 @@ public class AuctionService {
 
     @Transactional(readOnly = true)
     public SliceResponse<AuctionInfoResponse> getOtherAuctionsBySameMember(Long auctionId, Pageable pageable) {
-        Auction auction = auctionRepository.findById(auctionId)
+        Auction auction = auctionRepository.findByIdAndStatus(auctionId, Status.ACTIVE)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_NOT_FOUND));
         Member author = auction.getMember();
 
         Slice<Auction> auctions = auctionRepository.findAllByMemberAndStatusAndIdNot(author, Status.ACTIVE, auctionId, pageable);
 
         Slice<AuctionInfoResponse> auctionInfoResponses = auctions.map(otherAuction ->
-                AuctionInfoResponse.of(otherAuction, otherAuction.getItem(), otherAuction.getMember())
+                AuctionInfoResponse.of(otherAuction, otherAuction.getItem(), author)
         );
 
         return SliceResponse.from(auctionInfoResponses);

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/AuctionRepository.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/AuctionRepository.java
@@ -1,13 +1,19 @@
 package shop.sgmarket.sgmarketbackend.auction.repository;
 
 import java.util.Optional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import shop.sgmarket.sgmarketbackend.auction.domain.Auction;
 import shop.sgmarket.sgmarketbackend.global.domain.Status;
+import shop.sgmarket.sgmarketbackend.member.domain.Member;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long>, AuctionRepositoryCustom {
     Optional<Auction> findByIdAndStatus(Long id, Status status);
-    Page<Auction> findAllByStatus(Status status, Pageable pageable);
+    Slice<Auction> findAllByMemberAndStatusAndIdNot(
+            Member member,
+            Status status,
+            Long excludedAuctionId,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를 표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #38 

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- JPA를 활용하여 특정 경매 작성자의 다른 경매 목록을 조회하는 기능을 추가했습니다.
- 기존 `AuctionService`에 새로운 메서드 `getOtherAuctionsBySameMember`를 추가하여 특정 경매 작성자가 등록한 다른 경매를 조회할 수 있게 구현했습니다.
- `AuctionController`에 새로운 엔드포인트를 추가하여 API 호출 시 작성자의 다른 경매 목록을 조회할 수 있도록 했습니다.

<br/>

### ❄️ 주의할 점

--



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new API endpoint to view other active auctions by the same member who created a specified auction, with support for pagination.
- **Documentation**
  - Updated API documentation to include details for the new endpoint that retrieves other auctions by the same author.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->