### PR TITLE
회원 정보 조회 기능 구현

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidController.java
@@ -22,6 +22,7 @@ import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
 public class BidController implements BidDocs {
     private final BidService bidService;
 
+    @Override
     @PostMapping
     public ApiResponseTemplate<BidInfoResponse> bid(
             @PathVariable Long auctionId,
@@ -32,6 +33,7 @@ public class BidController implements BidDocs {
         return ApiResponseTemplate.created("입찰이 완료되었습니다", response);
     }
 
+    @Override
     @GetMapping
     public ApiResponseTemplate<SliceResponse<BidInfoResponse>> getBidsForAuction(
             @PathVariable Long auctionId,
@@ -42,6 +44,7 @@ public class BidController implements BidDocs {
         return ApiResponseTemplate.ok("입찰 목록 조회에 성공했습니다", response);
     }
 
+    @Override
     @PostMapping("/settle")
     public ApiResponseTemplate<BidInfoResponse> settleBid(@PathVariable Long auctionId) {
         BidInfoResponse response = bidService.settleBid(auctionId);

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidDocs.java
@@ -54,4 +54,19 @@ public interface BidDocs {
             @Parameter(description = "페이지네이션 정보 (정렬은 최신순으로 고정됩니다)")
             @ParameterObject Pageable pageable
     );
+
+    @Operation(
+            summary = "낙찰 처리",
+            description = "경매 종료 시 낙찰자를 확정합니다. 해당 경매의 최고 입찰자를 낙찰자로 설정합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "낙찰 처리가 완료되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "경매가 아직 종료되지 않았거나 낙찰 대상자가 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 ID의 경매가 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")
+            }
+    )
+    ApiResponseTemplate<BidInfoResponse> settleBid(
+            @Parameter(description = "낙찰 처리할 경매 ID", required = true)
+            Long auctionId
+    );
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
@@ -3,7 +3,7 @@ package shop.sgmarket.sgmarketbackend.member.api;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,7 +29,7 @@ public class MemberController implements MemberDocs {
     }
 
     @Override
-    @PostMapping
+    @PatchMapping
     public ApiResponseTemplate<MemberUpdateResponse> updateProfile(
             @RequestBody @Valid final MemberUpdateRequest memberUpdateRequest) {
 

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
@@ -2,6 +2,7 @@ package shop.sgmarket.sgmarketbackend.member.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
 import shop.sgmarket.sgmarketbackend.member.application.MemberService;
 import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
+import shop.sgmarket.sgmarketbackend.member.dto.response.MemberInfoResponse;
 import shop.sgmarket.sgmarketbackend.member.dto.response.MemberUpdateResponse;
 
 @RestController
@@ -17,7 +19,15 @@ import shop.sgmarket.sgmarketbackend.member.dto.response.MemberUpdateResponse;
 public class MemberController {
     private final MemberService memberService;
 
-    @PostMapping("/profile")
+    @GetMapping
+    public ApiResponseTemplate<MemberInfoResponse> getMemberInfo() {
+        MemberInfoResponse response = memberService.getMemberInfoFromId();
+
+        return ApiResponseTemplate.ok(response)
+                .message("회원 정보 조회 완료");
+    }
+
+    @PostMapping
     public ApiResponseTemplate<MemberUpdateResponse> updateProfile(
             @RequestBody @Valid final MemberUpdateRequest memberUpdateRequest) {
 

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
@@ -16,9 +16,10 @@ import shop.sgmarket.sgmarketbackend.member.dto.response.MemberUpdateResponse;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
-public class MemberController {
+public class MemberController implements MemberDocs {
     private final MemberService memberService;
 
+    @Override
     @GetMapping
     public ApiResponseTemplate<MemberInfoResponse> getMemberInfo() {
         MemberInfoResponse response = memberService.getMemberInfoFromId();
@@ -27,6 +28,7 @@ public class MemberController {
                 .message("회원 정보 조회 완료");
     }
 
+    @Override
     @PostMapping
     public ApiResponseTemplate<MemberUpdateResponse> updateProfile(
             @RequestBody @Valid final MemberUpdateRequest memberUpdateRequest) {

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
@@ -1,0 +1,51 @@
+package shop.sgmarket.sgmarketbackend.member.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
+import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
+import shop.sgmarket.sgmarketbackend.member.dto.response.MemberInfoResponse;
+import shop.sgmarket.sgmarketbackend.member.dto.response.MemberUpdateResponse;
+
+@Tag(name = "회원 API", description = "회원 관련 API입니다.")
+public interface MemberDocs {
+
+    @Operation(
+            summary = "회원 정보 조회",
+            description = "현재 로그인한 회원의 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", content = @Content(schema = @Schema(implementation = MemberInfoResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")
+            }
+    )
+    @GetMapping
+    ApiResponseTemplate<MemberInfoResponse> getMemberInfo();
+
+    @Operation(
+            summary = "회원 프로필 수정",
+            description = "회원의 닉네임, 주소 등을 수정합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "프로필 수정 요청 데이터",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = MemberUpdateRequest.class))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "프로필 수정 성공", content = @Content(schema = @Schema(implementation = MemberUpdateResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "유효하지 않은 요청입니다."),
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")
+            }
+    )
+    @PostMapping("/profile")
+    ApiResponseTemplate<MemberUpdateResponse> updateProfile(
+            @Parameter(hidden = true)
+            @RequestBody @Valid MemberUpdateRequest memberUpdateRequest
+    );
+}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
 import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
@@ -43,7 +43,7 @@ public interface MemberDocs {
                     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")
             }
     )
-    @PostMapping("/profile")
+    @PatchMapping
     ApiResponseTemplate<MemberUpdateResponse> updateProfile(
             @Parameter(hidden = true)
             @RequestBody @Valid MemberUpdateRequest memberUpdateRequest

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/application/MemberService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/application/MemberService.java
@@ -7,12 +7,20 @@ import shop.sgmarket.sgmarketbackend.global.util.MemberUtil;
 import shop.sgmarket.sgmarketbackend.member.domain.Member;
 import shop.sgmarket.sgmarketbackend.member.domain.MemberLocation;
 import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
+import shop.sgmarket.sgmarketbackend.member.dto.response.MemberInfoResponse;
 import shop.sgmarket.sgmarketbackend.member.dto.response.MemberUpdateResponse;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberUtil memberUtil;
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMemberInfoFromId() {
+        Member member = memberUtil.getCurrentMember();
+
+        return MemberInfoResponse.from(member);
+    }
 
     @Transactional
     public MemberUpdateResponse updateProfile(final MemberUpdateRequest memberUpdateRequest) {

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,27 @@
+package shop.sgmarket.sgmarketbackend.member.dto.response;
+
+import lombok.Builder;
+import shop.sgmarket.sgmarketbackend.member.domain.Member;
+
+@Builder
+public record MemberInfoResponse(
+        Long id,
+        String email,
+        String profileImageUrl,
+        String nickname,
+        String address,
+        Double latitude,
+        Double longitude
+) {
+    public static MemberInfoResponse from(Member member) {
+        return MemberInfoResponse.builder()
+                .id(member.getId())
+                .email(member.getOauthInfo().getOauthEmail())
+                .profileImageUrl(member.getOauthInfo().getOauthProfileImageUrl())
+                .nickname(member.getNickname())
+                .address(member.getLocation().getAddress())
+                .latitude(member.getLocation().getLatitude())
+                .longitude(member.getLocation().getLongitude())
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #48

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 회원 정보 조회 기능을 구현했습니다.
- 회원 기능 스웨거 문서를 작성했습니다.
- 기존 회원 정보 수정 기능을 patch 메서드로 변경했습니다.

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to retrieve the currently logged-in member's information.
  - Introduced a new API operation to finalize and settle the winning bidder for an auction.
- **Improvements**
  - Updated the member profile update endpoint to use the PATCH method.
  - Enhanced API documentation for member and auction-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->