### PR TITLE
경매 최대 제시가 기능 구현

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidController.java
@@ -51,4 +51,14 @@ public class BidController implements BidDocs {
 
         return ApiResponseTemplate.ok("낙찰 처리가 완료되었습니다", response);
     }
+
+    @Override
+    @GetMapping("/max")
+    public ApiResponseTemplate<BidInfoResponse> getMaxBidForAuction(
+            @PathVariable Long auctionId
+    ) {
+        BidInfoResponse response = bidService.getMaxBidForAuction(auctionId);
+
+        return ApiResponseTemplate.ok("경매 최대 입찰가 조회에 성공했습니다.", response);
+    }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/api/BidDocs.java
@@ -69,4 +69,18 @@ public interface BidDocs {
             @Parameter(description = "낙찰 처리할 경매 ID", required = true)
             Long auctionId
     );
+
+    @Operation(
+            summary = "경매 최대 입찰가 조회",
+            description = "특정 경매에서 현재까지 제시된 입찰 중 가장 높은 입찰가 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "경매 최대 입찰가 조회에 성공했습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 ID의 경매 또는 입찰이 존재하지 않습니다.")
+            }
+    )
+    ApiResponseTemplate<BidInfoResponse> getMaxBidForAuction(
+            @Parameter(description = "입찰 정보를 조회할 경매 ID", required = true)
+            Long auctionId
+    );
+
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
@@ -69,6 +69,16 @@ public class BidService {
 
         return BidInfoResponse.of(winningBid.getPrice(), winningBid.getMember());
     }
+    
+    @Transactional(readOnly = true)
+    public BidInfoResponse getMaxBidForAuction(Long auctionId) {
+        Auction auction = getAuctionOrThrow(auctionId);
+
+        Bid maxBid = bidRepository.findTopByAuctionOrderByPriceDesc(auction)
+                .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
+
+        return BidInfoResponse.of(maxBid.getPrice(), maxBid.getMember());
+    }
 
     private Auction getAuctionOrThrow(Long auctionId) {
         return auctionRepository.findById(auctionId)


### PR DESCRIPTION
### 🌳 이슈 번호

---

close #52

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

* 경매의 최대 입찰가를 조회하는 기능을 구현했습니다.
* Swagger 문서 (`BidDocs`)에 API 명세를 추가했습니다.

<br/>

### ❄️ 주의할 점

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to retrieve the highest bid for a specific auction.
  - Updated API documentation to include details about the new highest bid retrieval feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->