### PR TITLE
Item에 따라서 채팅방 생성 로직 변경

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/api/ChatController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/api/ChatController.java
@@ -18,8 +18,9 @@ import org.springframework.web.bind.annotation.*;
 import shop.sgmarket.sgmarketbackend.chat.application.ChatMessageService;
 import shop.sgmarket.sgmarketbackend.chat.application.ChatService;
 import shop.sgmarket.sgmarketbackend.chat.domain.ChatRoom;
-import shop.sgmarket.sgmarketbackend.chat.dto.ChatMessage;
-import shop.sgmarket.sgmarketbackend.chat.dto.DirectChatRequest;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.request.DirectChatRequest;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.DirectChatListResponse;
 import shop.sgmarket.sgmarketbackend.global.util.MemberUtil;
 
 import java.security.Principal;
@@ -95,19 +96,23 @@ public class ChatController {
             @RequestBody DirectChatRequest request
     ) {
         Long senderId = memberUtil.getCurrentMember().getId();
-        return chatService.createDirectChat(senderId, request.receiverId(), request.initialMessage());
+        return chatService.createDirectChat(senderId, request.receiverId(), request.itemId(), request.initialMessage());
     }
 
     @Operation(
             summary     = "내 DM 목록 조회",
-            description = "현재 로그인한 사용자가 참여 중인 모든 1:1 DM 채팅방을 반환합니다."
+            description = "현재 로그인한 사용자가 참여 중인 모든 1:1 DM 채팅방을 반환합니다. " +
+                         "각 채팅방의 상대방 정보와 마지막 메시지를 포함합니다."
     )
-    @ApiResponse(responseCode = "200", description = "조회 성공",
-            content = @Content(schema = @Schema(implementation = ChatRoom.class)))
+    @ApiResponse(
+        responseCode = "200", 
+        description = "조회 성공",
+        content = @Content(schema = @Schema(implementation = DirectChatListResponse.class))
+    )
     @GetMapping("/direct")
-    public List<ChatRoom> getDirectChats() {
+    public List<DirectChatListResponse> getDirectChats() {
         Long userId = memberUtil.getCurrentMember().getId();
-        return chatService.findDirectChats(userId);
+        return chatService.findDirectChatsWithDetails(userId);
     }
 
     // --------------------------- WebSocket --------------------------- //

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatMessageService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatMessageService.java
@@ -3,7 +3,7 @@ package shop.sgmarket.sgmarketbackend.chat.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import shop.sgmarket.sgmarketbackend.chat.dto.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
 
 import java.util.List;
 

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatService.java
@@ -1,8 +1,9 @@
 package shop.sgmarket.sgmarketbackend.chat.application;
 
 import shop.sgmarket.sgmarketbackend.chat.domain.ChatRoom;
-import shop.sgmarket.sgmarketbackend.chat.dto.ChatMessage;
-import shop.sgmarket.sgmarketbackend.chat.dto.DirectChatRequest;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.DirectChatListResponse;
+
 import java.util.List;
 
 public interface ChatService {
@@ -11,7 +12,10 @@ public interface ChatService {
     void sendMessage(ChatMessage message, String userId);
     
     // 1:1 채팅 관련 메서드 추가
-    ChatRoom createDirectChat(Long senderId, Long receiverId, String initialMessage);
+    ChatRoom createDirectChat(Long senderId, Long receiverId, Long itemId, String initialMessage);
     List<ChatRoom> findDirectChats(Long userId);
     boolean isDirectChat(String roomId);
+    
+    // DM 목록 조회 메서드 추가
+    List<DirectChatListResponse> findDirectChatsWithDetails(Long userId);
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatServiceImpl.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatServiceImpl.java
@@ -5,12 +5,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.sgmarket.sgmarketbackend.chat.domain.ChatRoom;
 import shop.sgmarket.sgmarketbackend.chat.domain.MessageType;
-import shop.sgmarket.sgmarketbackend.chat.dto.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.DirectChatListResponse;
 import shop.sgmarket.sgmarketbackend.chat.repository.ChatRoomRepository;
 import shop.sgmarket.sgmarketbackend.global.config.RedisPublisher;
+import shop.sgmarket.sgmarketbackend.global.error.ErrorCode;
+import shop.sgmarket.sgmarketbackend.global.error.exception.CustomException;
+import shop.sgmarket.sgmarketbackend.member.domain.Member;
+import shop.sgmarket.sgmarketbackend.member.repository.MemberRepository;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +26,7 @@ public class ChatServiceImpl implements ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final RedisPublisher redisPublisher;
     private final ChatMessageService chatMessageService;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional
@@ -48,16 +56,16 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional
-    public ChatRoom createDirectChat(Long senderId, Long receiverId, String initialMessage) {
+    public ChatRoom createDirectChat(Long senderId, Long receiverId, Long itemId, String initialMessage) {
         // 이미 존재하는 1:1 채팅방이 있는지 확인
-        ChatRoom existingRoom = chatRoomRepository.findDirectChat(senderId, receiverId);
+        ChatRoom existingRoom = chatRoomRepository.findDirectChat(senderId, receiverId, itemId);
         if (existingRoom != null) {
             return existingRoom;
         }
 
         // 새 1:1 채팅방 생성
         String roomId = UUID.randomUUID().toString();
-        String roomName = String.format("direct_%d_%d", Math.min(senderId, receiverId), Math.max(senderId, receiverId));
+        String roomName = String.format("direct_%d_%d_item_%d", Math.min(senderId, receiverId), Math.max(senderId, receiverId),itemId);
         
         ChatRoom room = ChatRoom.builder()
                 .id(roomId)
@@ -65,6 +73,7 @@ public class ChatServiceImpl implements ChatService {
                 .creatorId(senderId)
                 .isDirectChat(true)
                 .participantId(receiverId)
+                .itemId(itemId)
                 .build();
         
         ChatRoom savedRoom = chatRoomRepository.createRoom(room);
@@ -95,5 +104,38 @@ public class ChatServiceImpl implements ChatService {
     public boolean isDirectChat(String roomId) {
         ChatRoom room = chatRoomRepository.findRoomById(roomId);
         return room != null && room.isDirectChat();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DirectChatListResponse> findDirectChatsWithDetails(Long userId) {
+        List<ChatRoom> chatRooms = chatRoomRepository.findDirectChatsByUserId(userId);
+        
+        return chatRooms.stream()
+            .map(room -> {
+                // 상대방 ID 찾기
+                Long otherUserId = room.getCreatorId().equals(userId) 
+                    ? room.getParticipantId() 
+                    : room.getCreatorId();
+                
+                // 상대방 정보 조회
+                Member otherUser = memberRepository.findById(otherUserId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+                
+                // 마지막 메시지 조회
+                List<ChatMessage> messages = chatMessageService.getMessages(room.getId(), 1);
+                ChatMessage lastMessage = messages.isEmpty() ? null : messages.get(0);
+                
+                return new DirectChatListResponse(
+                    room.getId(),
+                    otherUserId,
+                    otherUser.getNickname(),
+                    otherUser.getOauthInfo().getOauthProfileImageUrl(),
+                    lastMessage != null ? lastMessage.message() : null,
+                    lastMessage != null ? lastMessage.createdAt() : null,
+                    room.getItemId()
+                );
+            })
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/domain/ChatRoom.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/domain/ChatRoom.java
@@ -19,14 +19,17 @@ public class ChatRoom {
     private LocalDateTime createdAt;
     private boolean isDirectChat;
     private Long participantId;  // 1:1 채팅의 경우 상대방 ID
+    private Long itemId;
 
     @Builder
-    public ChatRoom(String id, String name, Long creatorId, boolean isDirectChat, Long participantId) {
+    public ChatRoom(String id, String name, Long creatorId, boolean isDirectChat, Long participantId, Long itemId) {
         this.id = id;
         this.name = name;
         this.creatorId = creatorId;
         this.createdAt = LocalDateTime.now();
         this.isDirectChat = isDirectChat == true;  // null 체크
         this.participantId = participantId;
+        this.itemId = itemId;
+
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/DirectChatRequest.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/DirectChatRequest.java
@@ -1,6 +1,0 @@
-package shop.sgmarket.sgmarketbackend.chat.dto;
-
-public record DirectChatRequest(
-    Long receiverId,  // 채팅을 받을 사용자의 ID
-    String initialMessage  // 첫 메시지
-) {}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/request/DirectChatRequest.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/request/DirectChatRequest.java
@@ -1,0 +1,7 @@
+package shop.sgmarket.sgmarketbackend.chat.dto.request;
+
+public record DirectChatRequest(
+    Long receiverId, // 채팅을 받을 사용자의 ID
+    Long itemId, // 관련된 아이템의 ID (optional)
+    String initialMessage  // 첫 메시지
+) {}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/ChatMessage.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/ChatMessage.java
@@ -1,4 +1,4 @@
-package shop.sgmarket.sgmarketbackend.chat.dto;
+package shop.sgmarket.sgmarketbackend.chat.dto.response;
 
 import shop.sgmarket.sgmarketbackend.chat.domain.MessageType;
 import java.time.LocalDateTime;

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/DirectChatListResponse.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/DirectChatListResponse.java
@@ -1,0 +1,15 @@
+package shop.sgmarket.sgmarketbackend.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "DM 목록 응답")
+public record DirectChatListResponse(
+        @Schema(description = "채팅방 ID") String roomId,
+        @Schema(description = "상대방 ID") Long otherUserId,
+        @Schema(description = "상대방 닉네임") String otherUserNickname,
+        @Schema(description = "상대방 프로필 이미지 URL") String otherUserProfileImage,
+        @Schema(description = "마지막 메시지") String lastMessage,
+        @Schema(description = "마지막 메시지 시간") LocalDateTime lastMessageTime,
+        @Schema(description = "연결된 상품 ID") Long itemId
+) {}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/repository/ChatRoomRepository.java
@@ -42,8 +42,8 @@ public class ChatRoomRepository {
                 .getResultList();
     }
 
-    public ChatRoom findDirectChat(Long userId1, Long userId2) {
-        String roomName = String.format("direct_%d_%d", Math.min(userId1, userId2), Math.max(userId1, userId2));
+    public ChatRoom findDirectChat(Long userId1, Long userId2, Long itemId) {
+        String roomName = String.format("direct_%d_%d_item_%d", Math.min(userId1, userId2), Math.max(userId1, userId2),itemId);
         try {
             return em.createQuery("SELECT c FROM ChatRoom c WHERE c.name = :name AND c.isDirectChat = true", ChatRoom.class)
                     .setParameter("name", roomName)

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/config/RedisPublisher.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/config/RedisPublisher.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Service;
-import shop.sgmarket.sgmarketbackend.chat.dto.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
 
 @Slf4j
 @Service

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/config/RedisSubscriber.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/config/RedisSubscriber.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
-import shop.sgmarket.sgmarketbackend.chat.dto.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
 
 @Slf4j
 @Service


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

--- #70 

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #<!-- 번호 -->

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

--- Item의 id에 따라 채팅방을 다르게 생성하도록 수정했습니다.

- <!-- 실제로 해결한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Direct chat creation now supports associating chats with specific items.
  - The direct chat list response now displays additional details, including the other participant’s information, the last message, and the associated item.

- **Improvements**
  - Enhanced API responses for direct chats, providing richer information for users.
  - Updated API documentation to reflect the improved response structure and details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->