### PR TITLE
다른 회원의 경매 목록 조회 기능 추가

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
@@ -88,6 +88,4 @@ public class MemberController implements MemberDocs {
         return ApiResponseTemplate.ok(response)
                 .message("해당 멤버의 경매 목록 조회 완료");
     }
-
-
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
@@ -6,6 +6,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -68,6 +69,7 @@ public class MemberController implements MemberDocs {
                 .message("내가 입찰한 경매 목록 조회 완료");
     }
 
+    @Override
     @PatchMapping("/charge-coin")
     public ApiResponseTemplate<MemberInfoResponse> chargeCoin(@RequestBody @Valid ChargeCoinRequest chargeCoinRequest) {
         MemberInfoResponse response = memberService.chargeCoin(chargeCoinRequest);
@@ -75,4 +77,17 @@ public class MemberController implements MemberDocs {
         return ApiResponseTemplate.ok(response)
                 .message("코인 충전 완료");
     }
+
+    @GetMapping("/{memberId}/auctions")
+    public ApiResponseTemplate<SliceResponse<AuctionInfoResponse>> getAuctionsByMemberId(
+            @PathVariable Long memberId,
+            @ParameterObject Pageable pageable) {
+
+        SliceResponse<AuctionInfoResponse> response = memberService.getAuctionsByMemberId(memberId, pageable);
+
+        return ApiResponseTemplate.ok(response)
+                .message("해당 멤버의 경매 목록 조회 완료");
+    }
+
+
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
@@ -11,6 +11,7 @@ import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import shop.sgmarket.sgmarketbackend.auction.dto.response.AuctionInfoResponse;
 import shop.sgmarket.sgmarketbackend.global.dto.SliceResponse;
@@ -118,4 +119,22 @@ public interface MemberDocs {
             @RequestBody @Valid ChargeCoinRequest chargeCoinRequest
     );
 
+    @Operation(
+            summary = "특정 멤버의 경매 목록 조회",
+            description = "특정 멤버가 등록한 경매 목록을 페이지 단위로 조회합니다.",
+            parameters = {
+                    @Parameter(name = "memberId", description = "조회할 멤버의 ID", required = true, example = "1")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "해당 멤버의 경매 목록 조회 성공",
+                            content = @Content(schema = @Schema(implementation = SliceResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다."),
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")
+            }
+    )
+    @GetMapping("/{memberId}/auctions")
+    ApiResponseTemplate<SliceResponse<AuctionInfoResponse>> getAuctionsByMemberId(
+            @PathVariable Long memberId,
+            @ParameterObject Pageable pageable
+    );
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/application/MemberService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/application/MemberService.java
@@ -21,6 +21,7 @@ import shop.sgmarket.sgmarketbackend.member.domain.MemberLocation;
 import shop.sgmarket.sgmarketbackend.member.dto.request.ChargeCoinRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.response.MemberInfoResponse;
+import shop.sgmarket.sgmarketbackend.member.repository.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class MemberService {
     private final AuctionRepository auctionRepository;
     private final AuctionLikeRepository auctionLikeRepository;
     private final BidRepository bidRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfoFromId() {
@@ -73,7 +75,6 @@ public class MemberService {
         return SliceResponse.from(dtos);
     }
 
-
     @Transactional(readOnly = true)
     public SliceResponse<AuctionInfoResponse> getMyLikedAuctions(Pageable pageable) {
         Member member = memberUtil.getCurrentMember();
@@ -116,4 +117,27 @@ public class MemberService {
 
         return MemberInfoResponse.from(member);
     }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<AuctionInfoResponse> getAuctionsByMemberId(Long memberId, Pageable pageable) {
+        Member targetMember = memberUtil.getMemberByMemberId(memberId);
+
+        Member currentMember = memberUtil.getCurrentMember();
+
+        Slice<Auction> auctions = auctionRepository.findByMember(targetMember, pageable);
+
+        Slice<AuctionInfoResponse> responseSlice = auctions.map(auction -> {
+            boolean isLiked = auctionLikeRepository.existsByAuctionAndMember(auction, currentMember);
+
+            return AuctionInfoResponse.of(
+                    auction,
+                    auction.getItem(),
+                    targetMember,
+                    isLiked
+            );
+        });
+
+        return SliceResponse.from(responseSlice);
+    }
+
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #81

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 다른 회원의 경매 목록 조회 기능 추가하였습니다.
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to view a paginated list of auctions registered by a specific member.
  - Enhanced API documentation to include details for the new auctions-by-member endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->