### PR TITLE
입찰 시 코인 차감 및 낙찰 시 코인 환불

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
@@ -16,6 +16,7 @@ import shop.sgmarket.sgmarketbackend.auction.domain.Auction;
 import shop.sgmarket.sgmarketbackend.auction.domain.AuctionStatus;
 import shop.sgmarket.sgmarketbackend.auction.domain.Bid;
 import shop.sgmarket.sgmarketbackend.auction.domain.PriceHistory;
+import shop.sgmarket.sgmarketbackend.auction.dto.RefundAmount;
 import shop.sgmarket.sgmarketbackend.auction.dto.request.BidRegisterRequest;
 import shop.sgmarket.sgmarketbackend.auction.dto.response.BidInfoResponse;
 import shop.sgmarket.sgmarketbackend.auction.repository.auction.AuctionRepository;
@@ -97,15 +98,13 @@ public class BidService {
         priceHistoryRepository.save(priceHistory);
 
         Long winningBidId = winningBid.getId();
-        List<Object[]> refundData = bidRepository.findRefundAmountsByAuctionExceptWinning(auctionId, winningBidId);
+        List<RefundAmount> refundData = bidRepository.findRefundAmountsByAuctionExceptWinning(auctionId, winningBidId);
 
-        for (Object[] row : refundData) {
-            Long memberId    = (Long) row[0];
-            Long refundAmount = (Long) row[1];
-
-            Member bidderMember = memberUtil.getMemberByMemberId(memberId);
-            bidderMember.chargeCoin(refundAmount);
+        for (RefundAmount refundAmount : refundData) {
+            Member bidderMember = memberUtil.getMemberByMemberId(refundAmount.memberId());
+            bidderMember.chargeCoin(refundAmount.totalAmount());
         }
+
         notifyAuctionSettled(auction, winningBid);
 
         return BidInfoResponse.of(winningBid);

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
@@ -50,23 +50,16 @@ public class BidService {
         Member bidder = memberUtil.getCurrentMember();
         Auction auction = getAuctionOrThrow(auctionId);
 
+        validateBidderHasEnoughCoins(bidder, bidRequest.bidPrice());
         validateBiddingStatus(auction);
         validateNotOwner(bidder, auction);
 
         auction.updateCurrentPrice(bidRequest.bidPrice());
         Bid bid = Bid.createBid(bidder, auction, bidRequest.bidPrice());
-        bidRepository.save(bid);
 
-        String message = String.format(
-                BID_NOTIFICATION_MESSAGE,
-                auction.getTitle(),
-                bidRequest.bidPrice()
-        );
-        notificationService.createAndSendNotification(
-                auction.getMember(),
-                NotificationEventType.BID,
-                message
-        );
+        bidder.deductCoin(bidRequest.bidPrice());
+        bidRepository.save(bid);
+        sendBidNotification(auction, bidRequest);
 
         return BidInfoResponse.of(bid);
     }
@@ -93,7 +86,7 @@ public class BidService {
         validateBiddingStatus(auction);
         validateAuctionOwner(owner, auction);
 
-        Bid winningBid = bidRepository.findTopByAuctionOrderByCreatedAtDesc(auction)
+        Bid winningBid = bidRepository.findTopByAuctionOrderByCreatedAtDescPriceDesc(auction)
                 .orElseThrow(() -> new CustomException(ErrorCode.BID_NOT_FOUND));
 
         auction.updateStatus(AuctionStatus.COMPLETED);
@@ -103,6 +96,16 @@ public class BidService {
         );
         priceHistoryRepository.save(priceHistory);
 
+        Long winningBidId = winningBid.getId();
+        List<Object[]> refundData = bidRepository.findRefundAmountsByAuctionExceptWinning(auctionId, winningBidId);
+
+        for (Object[] row : refundData) {
+            Long memberId    = (Long) row[0];
+            Long refundAmount = (Long) row[1];
+
+            Member bidderMember = memberUtil.getMemberByMemberId(memberId);
+            bidderMember.chargeCoin(refundAmount);
+        }
         notifyAuctionSettled(auction, winningBid);
 
         return BidInfoResponse.of(winningBid);
@@ -153,6 +156,19 @@ public class BidService {
         notifyAuctionSettled(auction, highestBid);
     }
 
+    private void sendBidNotification(Auction auction, BidRegisterRequest bidRequest) {
+        String message = String.format(
+                BID_NOTIFICATION_MESSAGE,
+                auction.getTitle(),
+                bidRequest.bidPrice()
+        );
+        notificationService.createAndSendNotification(
+                auction.getMember(),
+                NotificationEventType.BID,
+                message
+        );
+    }
+
     private void notifyAuctionSettled(Auction auction, Bid winningBid) {
         String title = auction.getTitle();
         long price = winningBid.getPrice();
@@ -197,6 +213,12 @@ public class BidService {
     private Auction getAuctionOrThrow(Long auctionId) {
         return auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_NOT_FOUND));
+    }
+
+    private void validateBidderHasEnoughCoins(Member bidder, long bidPrice) {
+        if (bidder.getCoin() < bidPrice) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_COINS);
+        }
     }
 
     private void validateBiddingStatus(Auction auction) {

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
@@ -51,7 +51,6 @@ public class BidService {
         Member bidder = memberUtil.getCurrentMember();
         Auction auction = getAuctionOrThrow(auctionId);
 
-        validateBidderHasEnoughCoins(bidder, bidRequest.bidPrice());
         validateBiddingStatus(auction);
         validateNotOwner(bidder, auction);
 
@@ -212,12 +211,6 @@ public class BidService {
     private Auction getAuctionOrThrow(Long auctionId) {
         return auctionRepository.findById(auctionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUCTION_NOT_FOUND));
-    }
-
-    private void validateBidderHasEnoughCoins(Member bidder, long bidPrice) {
-        if (bidder.getCoin() < bidPrice) {
-            throw new CustomException(ErrorCode.INSUFFICIENT_COINS);
-        }
     }
 
     private void validateBiddingStatus(Auction auction) {

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/application/BidService.java
@@ -99,11 +99,7 @@ public class BidService {
         Long winningBidId = winningBid.getId();
         List<RefundAmount> refundData = bidRepository.findRefundAmountsByAuctionExceptWinning(auctionId, winningBidId);
 
-        for (RefundAmount refundAmount : refundData) {
-            Member bidderMember = memberUtil.getMemberByMemberId(refundAmount.memberId());
-            bidderMember.chargeCoin(refundAmount.totalAmount());
-        }
-
+        processRefunds(refundData);
         notifyAuctionSettled(auction, winningBid);
 
         return BidInfoResponse.of(winningBid);
@@ -152,6 +148,18 @@ public class BidService {
         priceHistoryRepository.save(priceHistory);
 
         notifyAuctionSettled(auction, highestBid);
+    }
+
+    private void processRefunds(List<RefundAmount> refundData) {
+        for (RefundAmount refundAmount : refundData) {
+            try {
+                Member bidderMember = memberUtil.getMemberByMemberId(refundAmount.memberId());
+                bidderMember.chargeCoin(refundAmount.totalAmount());
+            } catch (CustomException e) {
+                log.error("환불 실패: memberId={}, amount={}, reason={}",
+                        refundAmount.memberId(), refundAmount.totalAmount(), e.getMessage());
+            }
+        }
     }
 
     private void sendBidNotification(Auction auction, BidRegisterRequest bidRequest) {

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/dto/RefundAmount.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/dto/RefundAmount.java
@@ -1,0 +1,3 @@
+package shop.sgmarket.sgmarketbackend.auction.dto;
+
+public record RefundAmount(Long memberId, Long totalAmount) { }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepository.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepository.java
@@ -9,6 +9,6 @@ import shop.sgmarket.sgmarketbackend.auction.domain.Bid;
 
 public interface BidRepository extends JpaRepository<Bid, Long>, BidRepositoryCustom {
     Slice<Bid> findAllByAuction(Auction auction, Pageable pageable);
-    Optional<Bid> findTopByAuctionOrderByCreatedAtDesc(Auction auction);
+    Optional<Bid> findTopByAuctionOrderByCreatedAtDescPriceDesc(Auction auction);
     Optional<Bid> findTopByAuctionOrderByPriceDesc(Auction auction);
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryCustom.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryCustom.java
@@ -4,11 +4,12 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import shop.sgmarket.sgmarketbackend.auction.domain.Auction;
+import shop.sgmarket.sgmarketbackend.auction.dto.RefundAmount;
 import shop.sgmarket.sgmarketbackend.member.domain.Member;
 
 public interface BidRepositoryCustom {
     Slice<Auction> findAuctionsByMember(Member member, Pageable pageable);
-    List<Object[]> findRefundAmountsByAuctionExceptWinning(
+    List<RefundAmount> findRefundAmountsByAuctionExceptWinning(
             Long auctionId,
             Long winningBidId
     );

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryCustom.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryCustom.java
@@ -1,5 +1,6 @@
 package shop.sgmarket.sgmarketbackend.auction.repository.bid;
 
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import shop.sgmarket.sgmarketbackend.auction.domain.Auction;
@@ -7,4 +8,8 @@ import shop.sgmarket.sgmarketbackend.member.domain.Member;
 
 public interface BidRepositoryCustom {
     Slice<Auction> findAuctionsByMember(Member member, Pageable pageable);
+    List<Object[]> findRefundAmountsByAuctionExceptWinning(
+            Long auctionId,
+            Long winningBidId
+    );
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryImpl.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import shop.sgmarket.sgmarketbackend.auction.domain.Auction;
 import shop.sgmarket.sgmarketbackend.auction.domain.QBid;
+import shop.sgmarket.sgmarketbackend.auction.dto.RefundAmount;
 import shop.sgmarket.sgmarketbackend.member.domain.Member;
 
 @RequiredArgsConstructor
@@ -36,7 +37,7 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
     }
 
     @Override
-    public List<Object[]> findRefundAmountsByAuctionExceptWinning(Long auctionId, Long winningBidId) {
+    public List<RefundAmount> findRefundAmountsByAuctionExceptWinning(Long auctionId, Long winningBidId) {
         List<Tuple> tuples = queryFactory
                 .select(bid.member.id, bid.price.sum())
                 .from(bid)
@@ -48,10 +49,10 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
                 .fetch();
 
         return tuples.stream()
-                .map(t -> new Object[]{
+                .map(t -> new RefundAmount(
                         t.get(bid.member.id),
                         t.get(bid.price.sum())
-                })
+                ))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryImpl.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/bid/BidRepositoryImpl.java
@@ -1,7 +1,9 @@
 package shop.sgmarket.sgmarketbackend.auction.repository.bid;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -31,5 +33,25 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
         }
 
         return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
+    public List<Object[]> findRefundAmountsByAuctionExceptWinning(Long auctionId, Long winningBidId) {
+        List<Tuple> tuples = queryFactory
+                .select(bid.member.id, bid.price.sum())
+                .from(bid)
+                .where(
+                        bid.auction.id.eq(auctionId)
+                                .and(bid.id.ne(winningBidId))
+                )
+                .groupBy(bid.member.id)
+                .fetch();
+
+        return tuples.stream()
+                .map(t -> new Object[]{
+                        t.get(bid.member.id),
+                        t.get(bid.price.sum())
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     NOT_AUCTION_OWNER(HttpStatus.FORBIDDEN, "AUCTION_4031", "경매의 판매자가 아닙니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_4002", "결제 금액이 일치하지 않습니다."),
     PAYMENT_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "PAYMENT_4003", "결제가 완료되지 않았습니다."),
+    INSUFFICIENT_COINS(HttpStatus.BAD_REQUEST, "MEMBER_4001", "코인이 부족합니다."),
 
     // 401 UNAUTHORIZED
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "AUTH_4011", "인증이 필요합니다."),

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/domain/Member.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/domain/Member.java
@@ -17,6 +17,8 @@ import lombok.NoArgsConstructor;
 import shop.sgmarket.sgmarketbackend.auth.domain.OAuthProvider;
 import shop.sgmarket.sgmarketbackend.global.domain.BaseTimeEntity;
 import shop.sgmarket.sgmarketbackend.global.domain.Status;
+import shop.sgmarket.sgmarketbackend.global.error.ErrorCode;
+import shop.sgmarket.sgmarketbackend.global.error.exception.CustomException;
 
 @Entity
 @Getter
@@ -90,5 +92,12 @@ public class Member extends BaseTimeEntity {
 
     public void chargeCoin(final Long price) {
         coin += price;
+    }
+
+    public void deductCoin(final Long price) {
+        if (coin < price) {
+            throw new CustomException(ErrorCode.INSUFFICIENT_COINS, "잔액이 부족합니다.");
+        }
+        coin -= price;
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/domain/Member.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/domain/Member.java
@@ -96,7 +96,7 @@ public class Member extends BaseTimeEntity {
 
     public void deductCoin(final Long price) {
         if (coin < price) {
-            throw new CustomException(ErrorCode.INSUFFICIENT_COINS, "잔액이 부족합니다.");
+            throw new CustomException(ErrorCode.INSUFFICIENT_COINS);
         }
         coin -= price;
     }


### PR DESCRIPTION


<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #89

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 입찰 시 사용자의 코인을 차감하고, 잔액 부족 시 INSUFFICIENT_COINS 에러 반환
- 최종 낙찰 완료 시 낙찰자를 제외한 모든 입찰자에게 코인 환불 처리
<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added validation to ensure bidders have enough coins before placing a bid.
	- Implemented automatic coin deduction for successful bids and refunds for losing bidders after auction settlement.
	- Introduced a new error message for insufficient coin balance during bidding.

- **Bug Fixes**
	- Improved accuracy in selecting the winning bid by updating the bid selection criteria.

- **Chores**
	- Enhanced notification handling for new bids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->