### PR TITLE
멤버 코인 정보도 반환하도록 수정

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/dto/response/AuctionInfoResponse.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/dto/response/AuctionInfoResponse.java
@@ -68,7 +68,8 @@ public record AuctionInfoResponse(
     public record MemberInfo(
             Long memberId,
             String memberName,
-            String memberProfileImageUrl
+            String memberProfileImageUrl,
+            Long coin
     ) {
 
         @QueryProjection
@@ -80,6 +81,7 @@ public record AuctionInfoResponse(
                     .memberId(member.getId())
                     .memberName(member.getNickname())
                     .memberProfileImageUrl(member.getOauthInfo().getOauthProfileImageUrl())
+                    .coin(member.getCoin())
                     .build();
         }
     }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/auction/AuctionRepositoryImpl.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/auction/repository/auction/AuctionRepositoryImpl.java
@@ -147,7 +147,8 @@ public class AuctionRepositoryImpl implements AuctionRepositoryCustom {
                         new QAuctionInfoResponse_MemberInfo(
                                 auction.member.id,
                                 auction.member.nickname,
-                                auction.member.oauthInfo.oauthProfileImageUrl
+                                auction.member.oauthInfo.oauthProfileImageUrl,
+                                auction.member.coin
                         ),
                         auction.status.stringValue()
                 ))


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #94

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 입찰할 때, 사용하기 위해 멤버 코인 정보도 AuctionInfoResponse에 포함시킵니다.
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Member information in auction responses now includes the member's coin balance. This provides more detailed account information when viewing auction details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->