### PR TITLE
채팅방 상세 정보 API 추가

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/api/ChatController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/api/ChatController.java
@@ -22,6 +22,7 @@ import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
 import shop.sgmarket.sgmarketbackend.chat.dto.request.DirectChatRequest;
 import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessagePage;
 import shop.sgmarket.sgmarketbackend.chat.dto.response.DirectChatListResponse;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatRoomActionResponse;
 import shop.sgmarket.sgmarketbackend.global.util.MemberUtil;
 import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
 
@@ -187,5 +188,15 @@ public class ChatController {
             @RequestParam(defaultValue = "50") int size
     ) {
         return ApiResponseTemplate.ok(chatMessageService.getMessagesPage(roomId, cursor, size));
+    }
+
+    @Operation(
+        summary = "채팅방 메타데이터",
+        description = "• 경매 상세로 이동할 itemId\n• 거래하기(낙찰) URL을 한 번에 제공합니다.",
+        parameters = @Parameter(name = "roomId", required = true)
+    )
+    @GetMapping("/room/{roomId}/meta")
+    public ApiResponseTemplate<ChatRoomActionResponse> getRoomActions(@PathVariable String roomId) {
+        return ApiResponseTemplate.ok(chatService.getChatRoomActions(roomId));
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatService.java
@@ -2,6 +2,7 @@ package shop.sgmarket.sgmarketbackend.chat.application;
 
 import shop.sgmarket.sgmarketbackend.chat.domain.ChatRoom;
 import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatRoomActionResponse;
 import shop.sgmarket.sgmarketbackend.chat.dto.response.DirectChatListResponse;
 
 import java.util.List;
@@ -20,4 +21,6 @@ public interface ChatService {
     List<DirectChatListResponse> findDirectChatsWithDetails(Long userId);
 
     void deleteRoom(String roomId);
+
+    ChatRoomActionResponse getChatRoomActions(String roomId);
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatServiceImpl.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.sgmarket.sgmarketbackend.chat.domain.ChatRoom;
 import shop.sgmarket.sgmarketbackend.chat.domain.MessageType;
 import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatMessage;
+import shop.sgmarket.sgmarketbackend.chat.dto.response.ChatRoomActionResponse;
 import shop.sgmarket.sgmarketbackend.chat.dto.response.DirectChatListResponse;
 import shop.sgmarket.sgmarketbackend.chat.repository.ChatRoomRepository;
 import shop.sgmarket.sgmarketbackend.global.config.RedisPublisher;
@@ -135,5 +136,18 @@ public class ChatServiceImpl implements ChatService {
     public void deleteRoom(String roomId) {
         chatRoomRepository.deleteRoom(roomId);
         chatMessageService.deleteMessages(roomId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChatRoomActionResponse getChatRoomActions(String roomId) {
+        ChatRoom room = chatRoomRepository.findRoomById(roomId);
+        if (room == null) throw new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND);
+
+        Long itemId = room.getItemId();
+        String detail = "/auction/" + itemId;          // 경매 진행 살펴보기
+        String trade  = "/auction/" + itemId + "/bid"; // 거래(낙찰) 페이지
+
+        return new ChatRoomActionResponse(itemId, detail, trade);
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatServiceImpl.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/application/ChatServiceImpl.java
@@ -42,14 +42,21 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     public void sendMessage(ChatMessage message, String userId) {
+        Member sender = memberRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        MessageType type = message.type() != null ? message.type() : MessageType.TALK;
+
         ChatMessage authenticatedMessage = new ChatMessage(
                 message.roomId(),
-                message.sender(),
+                sender.getNickname(),
                 userId,
+                sender.getOauthInfo().getOauthProfileImageUrl(),
                 message.message(),
-                message.type(),
+                type,
                 LocalDateTime.now()
         );
+        
         redisPublisher.publish(authenticatedMessage);
         chatMessageService.saveMessage(authenticatedMessage.roomId(), authenticatedMessage);
     }
@@ -57,42 +64,33 @@ public class ChatServiceImpl implements ChatService {
     @Override
     @Transactional
     public ChatRoom createDirectChat(Long senderId, Long receiverId, Long itemId, String initialMessage) {
-        // 이미 존재하는 1:1 채팅방이 있는지 확인
         ChatRoom existingRoom = chatRoomRepository.findDirectChat(senderId, receiverId, itemId);
         if (existingRoom != null) {
             return existingRoom;
         }
 
-        // 새 1:1 채팅방 생성
         String roomId = UUID.randomUUID().toString();
-        String roomName = String.format("direct_%d_%d_item_%d", 
-            Math.min(senderId, receiverId), 
-            Math.max(senderId, receiverId),
-            itemId);
-        
-        ChatRoom room = ChatRoom.builder()
-                .id(roomId)
-                .name(roomName)
-                .creatorId(senderId)
-                .isDirectChat(true)
-                .participantId(receiverId)
-                .itemId(itemId)
-                .build();
-        
+        String roomName = String.format("direct_%d_%d_item_%d", Math.min(senderId, receiverId), Math.max(senderId, receiverId), itemId);
+
+        ChatRoom room = ChatRoom.builder().id(roomId).name(roomName).creatorId(senderId).isDirectChat(true).participantId(receiverId).itemId(itemId).build();
+
         ChatRoom savedRoom = chatRoomRepository.createRoom(room);
 
-        // 초기 메시지가 있고 비어있지 않은 경우에만 전송
         if (initialMessage != null && !initialMessage.trim().isEmpty()) {
+            Member senderMember = memberRepository.findById(senderId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+            
             ChatMessage message = new ChatMessage(
-                roomId,
-                "System",
-                senderId.toString(),
-                initialMessage,
-                MessageType.TALK,
-                LocalDateTime.now()
+                    roomId,
+                    senderMember.getNickname(),
+                    senderId.toString(),
+                    senderMember.getOauthInfo().getOauthProfileImageUrl(),
+                    initialMessage,
+                    MessageType.TALK,
+                    LocalDateTime.now()
             );
             redisPublisher.publish(message);
-            chatMessageService.saveMessage(roomId, message);  // 메시지 저장 추가
+            chatMessageService.saveMessage(roomId, message);
         }
 
         return savedRoom;
@@ -114,39 +112,28 @@ public class ChatServiceImpl implements ChatService {
     @Transactional(readOnly = true)
     public List<DirectChatListResponse> findDirectChatsWithDetails(Long userId) {
         List<ChatRoom> chatRooms = chatRoomRepository.findDirectChatsByUserId(userId);
-        
-        return chatRooms.stream()
-            .map(room -> {
-                // 상대방 ID 찾기
-                Long otherUserId = room.getCreatorId().equals(userId) 
-                    ? room.getParticipantId() 
-                    : room.getCreatorId();
-                
-                // 상대방 정보 조회
-                Member otherUser = memberRepository.findById(otherUserId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-                
-                // 마지막 메시지 조회
-                List<ChatMessage> messages = chatMessageService.getMessages(room.getId(), 1);
-                ChatMessage lastMessage = messages.isEmpty() ? null : messages.get(0);
-                
-                return new DirectChatListResponse(
-                    room.getId(),
-                    otherUserId,
-                    otherUser.getNickname(),
-                    otherUser.getOauthInfo().getOauthProfileImageUrl(),
-                    lastMessage != null ? lastMessage.message() : null,
-                    lastMessage != null ? lastMessage.createdAt() : null,
-                    room.getItemId()
-                );
-            })
-            .collect(Collectors.toList());
+
+        return chatRooms.stream().map(room -> {
+            // 상대방 ID 찾기
+            Long otherUserId = room.getCreatorId().equals(userId) ? room.getParticipantId() : room.getCreatorId();
+
+            // 상대방 정보 조회
+            Member otherUser = memberRepository.findById(otherUserId).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+            // 마지막 메시지 조회
+            List<ChatMessage> messages = chatMessageService.getMessages(room.getId(), 1);
+            ChatMessage lastMessage = messages.isEmpty() ? null : messages.get(0);
+
+            String locationName = otherUser.getLocation() != null ? otherUser.getLocation().getAddress() : null;
+
+            return new DirectChatListResponse(room.getId(), otherUserId, otherUser.getNickname(), otherUser.getOauthInfo().getOauthProfileImageUrl(),locationName, lastMessage != null ? lastMessage.message() : null, lastMessage != null ? lastMessage.createdAt() : null, room.getItemId());
+        }).collect(Collectors.toList());
     }
 
     @Override
     @Transactional
     public void deleteRoom(String roomId) {
-        chatRoomRepository.deleteRoom(roomId);      // DB 삭제
-        chatMessageService.deleteMessages(roomId);  // Redis 삭제
+        chatRoomRepository.deleteRoom(roomId);
+        chatMessageService.deleteMessages(roomId);
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/ChatMessage.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/ChatMessage.java
@@ -9,6 +9,7 @@ public record ChatMessage(
         @Schema(description = "채팅방 ID") String roomId,
         @Schema(description = "보낸 사람 닉네임") String sender,
         @Schema(description = "보낸 사람 ID") String senderId,
+        @Schema(description = "프로필 이미지") String profileImage,
         @Schema(description = "메시지 내용") String message,
         @Schema(description = "메시지 타입 (ENTER, TALK, LEAVE)") MessageType type,
         @Schema(description = "생성 시각") LocalDateTime createdAt

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/ChatRoomActionResponse.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/ChatRoomActionResponse.java
@@ -1,0 +1,10 @@
+package shop.sgmarket.sgmarketbackend.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방-상세 액션 정보")
+public record ChatRoomActionResponse(
+        @Schema(description = "경매(상품) ID")  Long itemId,
+        @Schema(description = "상세 페이지 URL") String detailUrl,
+        @Schema(description = "거래(낙찰) 페이지 URL") String tradeUrl
+) {} 

--- a/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/DirectChatListResponse.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/chat/dto/response/DirectChatListResponse.java
@@ -10,6 +10,7 @@ public record DirectChatListResponse(
         @Schema(description = "상대방 닉네임") String otherUserNickname,
         @Schema(description = "상대방 프로필 이미지 URL") String otherUserProfileImage,
         @Schema(description = "마지막 메시지") String lastMessage,
+        @Schema(description = "상대방의 지역 이름") String locationName,
         @Schema(description = "마지막 메시지 시간") LocalDateTime lastMessageTime,
         @Schema(description = "연결된 상품 ID") Long itemId
 ) {}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketConfig.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketConfig.java
@@ -3,23 +3,28 @@ package shop.sgmarket.sgmarketbackend.global.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.web.socket.config.WebSocketMessageBrokerStats;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final WebSocketMessageBrokerStats brokerStats = new WebSocketMessageBrokerStats();
+
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub");
+        registry.enableSimpleBroker("/sub")
+                .setHeartbeatValue(new long[]{10000, 10000}); // 10초마다 heartbeat
         registry.setApplicationDestinationPrefixes("/pub");
     }
 
@@ -27,6 +32,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureWebSocketTransport(WebSocketTransportRegistration registry) {
+        registry.setSendTimeLimit(15000)           // 15초 send timeout
+                .setSendBufferSizeLimit(512 * 1024)
+                .setMessageSizeLimit(128 * 1024);
     }
 
     @Override
@@ -40,8 +52,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                     String token = accessor.getFirstNativeHeader("Authorization");
                     if (token != null && token.startsWith("Bearer ")) {
                         token = token.substring(7);
-                        // JWT 토큰 검증 및 사용자 정보 설정
-                        // ... 토큰 검증 로직
                     }
                 }
                 return message;

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketConfig.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketConfig.java
@@ -14,6 +14,9 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -24,7 +27,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/sub")
-                .setHeartbeatValue(new long[]{10000, 10000}); // 10초마다 heartbeat
+                .setHeartbeatValue(new long[]{10000, 10000}) // 10초마다 heartbeat
+                .setTaskScheduler(heartbeatScheduler());
         registry.setApplicationDestinationPrefixes("/pub");
     }
 
@@ -58,4 +62,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             }
         });
     }
+
+    @Bean
+    public ThreadPoolTaskScheduler heartbeatScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("wss-heartbeat-thread-");
+        scheduler.initialize();
+        return scheduler;
+    }
+
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketSessionManager.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketSessionManager.java
@@ -1,0 +1,68 @@
+package shop.sgmarket.sgmarketbackend.global.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.*;
+
+@Component
+@Slf4j
+public class WebSocketSessionManager {
+
+    @Getter
+    private static class SessionWrapper {
+        private final WebSocketSession session;
+        private final Instant lastActiveTime;
+
+        public SessionWrapper(WebSocketSession session) {
+            this.session = session;
+            this.lastActiveTime = Instant.now();
+        }
+
+    }
+
+    private final Map<String, SessionWrapper> sessions = new ConcurrentHashMap<>();
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private static final long INACTIVITY_LIMIT_MINUTES = 30;
+
+    @PostConstruct
+    public void init() {
+        scheduler.scheduleWithFixedDelay(this::cleanupSessions, 1, 1, TimeUnit.MINUTES);
+    }
+
+    @PreDestroy
+    public void destroy() {
+        scheduler.shutdown();
+    }
+
+    private void cleanupSessions() {
+        Instant now = Instant.now();
+        sessions.entrySet().removeIf(entry -> {
+            SessionWrapper wrapper = entry.getValue();
+            try {
+                WebSocketSession session = wrapper.getSession();
+                if (!session.isOpen()) {
+                    log.info("Removing closed session: {}", entry.getKey());
+                    return true;
+                }
+                long inactiveMinutes = Duration.between(wrapper.getLastActiveTime(), now).toMinutes();
+                if (inactiveMinutes >= INACTIVITY_LIMIT_MINUTES) {
+                    log.info("Removing inactive session ({} minutes): {}", inactiveMinutes, entry.getKey());
+                    session.close();
+                    return true;
+                }
+                return false;
+            } catch (Exception e) {
+                log.warn("Error checking session {}: {}", entry.getKey(), e.getMessage());
+                return true;
+            }
+        });
+    }
+}

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketSessionManager.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketSessionManager.java
@@ -10,7 +10,10 @@ import org.springframework.web.socket.WebSocketSession;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @Slf4j
@@ -19,7 +22,7 @@ public class WebSocketSessionManager {
     @Getter
     private static class SessionWrapper {
         private final WebSocketSession session;
-        private final Instant lastActiveTime;
+        private Instant lastActiveTime;
 
         public SessionWrapper(WebSocketSession session) {
             this.session = session;
@@ -40,6 +43,14 @@ public class WebSocketSessionManager {
     @PreDestroy
     public void destroy() {
         scheduler.shutdown();
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                scheduler.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            scheduler.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 
     private void cleanupSessions() {

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketSessionManager.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/config/WebSocketSessionManager.java
@@ -49,18 +49,18 @@ public class WebSocketSessionManager {
             try {
                 WebSocketSession session = wrapper.getSession();
                 if (!session.isOpen()) {
-                    log.info("Removing closed session: {}", entry.getKey());
+                    log.info("비활성화된 세션을 제거합니다.: {}", entry.getKey());
                     return true;
                 }
                 long inactiveMinutes = Duration.between(wrapper.getLastActiveTime(), now).toMinutes();
                 if (inactiveMinutes >= INACTIVITY_LIMIT_MINUTES) {
-                    log.info("Removing inactive session ({} minutes): {}", inactiveMinutes, entry.getKey());
+                    log.info("비활성 세션 제거 중...  ({}분): {}", inactiveMinutes, entry.getKey());
                     session.close();
                     return true;
                 }
                 return false;
             } catch (Exception e) {
-                log.warn("Error checking session {}: {}", entry.getKey(), e.getMessage());
+                log.warn("세션 확인 중 오류 발생 {}: {}", entry.getKey(), e.getMessage());
                 return true;
             }
         });

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
     BID_NOT_FOUND(HttpStatus.NOT_FOUND, "AUCTION_4043", "입찰을 찾을 수 없습니다."),
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_4041", "주문 내역을 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND,"NOTIFICATION_4041","알림을 찾을 수 없습니다."),
+    CHAT_ROOM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"ROOM_4041" ,"채팅방을 찾을 수 없습니다." ),
+
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYSTEM_5001", "서버 내부 오류가 발생했습니다."),
@@ -51,8 +53,8 @@ public enum ErrorCode {
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_5001", "이미지 업로드에 실패했습니다."),
     MISSING_S3_BUCKET_CONFIG(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_5002", "S3 bucket 설정이 비어 있습니다."),
     MISSING_S3_REGION_CONFIG(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_5003", "S3 region 설정이 비어 있습니다."),
-    PAYMENT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT_5001", "결제 처리 중 오류가 발생했습니다."),
-    CHAT_ROOM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"ROOM_5001" ,"채팅방을 찾을 수 없습니다." );
+    PAYMENT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT_5001", "결제 처리 중 오류가 발생했습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/global/error/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
     MISSING_S3_BUCKET_CONFIG(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_5002", "S3 bucket 설정이 비어 있습니다."),
     MISSING_S3_REGION_CONFIG(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE_5003", "S3 region 설정이 비어 있습니다."),
     PAYMENT_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT_5001", "결제 처리 중 오류가 발생했습니다."),
-    ;
+    CHAT_ROOM_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR,"ROOM_5001" ,"채팅방을 찾을 수 없습니다." );
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,12 +4,11 @@ spring:
   profiles:
     group:
       test: "test"
-      local: "local, datasource"
-      dev: "dev, datasource"
-      prod: "prod, datasource"
+      local: "local, datasource, redis"
+      dev: "dev, datasource, redis"
+      prod: "prod, datasource, redis"
     include:
       - security
-      - redis
       - cloud
       - imp
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

- #103 

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #<!-- 번호 -->

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

- 특정 채팅방의 메타 데이터를 반환하도록 했습니다.

- <!-- 실제로 해결한 로직을 써주세요, 이슈에 쓴 로직과 달라도, 또는 같아도 좋습니다. -->
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new API endpoint to retrieve chat room metadata, including auction item details and transaction URLs.
  - Chat messages now display the sender’s profile image.
  - The chat list now shows the other user's location name.
  - Introduced improved WebSocket configuration with heartbeat support and enhanced transport settings.
  - Added automatic management and cleanup of inactive WebSocket sessions.

- **Bug Fixes**
  - Added a specific error message for cases when a chat room is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->