### PR TITLE
특정 회원의 구매 목록 조회 기능 추가

### DIFF
--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberController.java
@@ -17,6 +17,7 @@ import shop.sgmarket.sgmarketbackend.member.application.MemberService;
 import shop.sgmarket.sgmarketbackend.member.dto.request.ChargeCoinRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.response.MemberInfoResponse;
+import shop.sgmarket.sgmarketbackend.order.dto.response.OrderResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -97,5 +98,17 @@ public class MemberController implements MemberDocs {
 
         return ApiResponseTemplate.ok(response)
                 .message("해당 멤버의 경매 목록 조회 완료");
+    }
+
+    @Override
+    @GetMapping("/{memberId}/orders")
+    public ApiResponseTemplate<SliceResponse<OrderResponse>> getOrdersByMemberId(
+            @PathVariable Long memberId,
+            @ParameterObject Pageable pageable) {
+
+        SliceResponse<OrderResponse> response = memberService.getOrdersByMemberId(memberId, pageable);
+
+        return ApiResponseTemplate.ok(response)
+                .message("해당 멤버의 주문 목록 조회 완료");
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/api/MemberDocs.java
@@ -19,6 +19,7 @@ import shop.sgmarket.sgmarketbackend.global.response.ApiResponseTemplate;
 import shop.sgmarket.sgmarketbackend.member.dto.request.ChargeCoinRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.response.MemberInfoResponse;
+import shop.sgmarket.sgmarketbackend.order.dto.response.OrderResponse;
 
 @Tag(name = "회원 API", description = "회원 관련 API입니다.")
 public interface MemberDocs {
@@ -150,6 +151,25 @@ public interface MemberDocs {
     )
     @GetMapping("/{memberId}/auctions")
     ApiResponseTemplate<SliceResponse<AuctionInfoResponse>> getAuctionsByMemberId(
+            @PathVariable Long memberId,
+            @ParameterObject Pageable pageable
+    );
+
+    @Operation(
+            summary = "특정 멤버의 구매 목록 조회",
+            description = "특정 멤버가 주문한 목록을 페이지 단위로 조회합니다.",
+            parameters = {
+                    @Parameter(name = "memberId", description = "조회할 멤버의 ID", required = true, example = "1")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "해당 멤버의 주문 목록 조회 성공",
+                            content = @Content(schema = @Schema(implementation = SliceResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다."),
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.")
+            }
+    )
+    @GetMapping("/{memberId}/orders")
+    ApiResponseTemplate<SliceResponse<OrderResponse>> getOrdersByMemberId(
             @PathVariable Long memberId,
             @ParameterObject Pageable pageable
     );

--- a/src/main/java/shop/sgmarket/sgmarketbackend/member/application/MemberService.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/member/application/MemberService.java
@@ -21,7 +21,9 @@ import shop.sgmarket.sgmarketbackend.member.domain.MemberLocation;
 import shop.sgmarket.sgmarketbackend.member.dto.request.ChargeCoinRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.request.MemberUpdateRequest;
 import shop.sgmarket.sgmarketbackend.member.dto.response.MemberInfoResponse;
-import shop.sgmarket.sgmarketbackend.member.repository.MemberRepository;
+import shop.sgmarket.sgmarketbackend.order.domain.Order;
+import shop.sgmarket.sgmarketbackend.order.domain.repository.OrderRepository;
+import shop.sgmarket.sgmarketbackend.order.dto.response.OrderResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +32,7 @@ public class MemberService {
     private final AuctionRepository auctionRepository;
     private final AuctionLikeRepository auctionLikeRepository;
     private final BidRepository bidRepository;
-    private final MemberRepository memberRepository;
+    private final OrderRepository orderRepository;
 
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfoFromId() {
@@ -145,5 +147,17 @@ public class MemberService {
         });
 
         return SliceResponse.from(responseSlice);
+    }
+
+    @Transactional(readOnly = true)
+    public SliceResponse<OrderResponse> getOrdersByMemberId(Long memberId, Pageable pageable) {
+
+        Member targetMember = memberUtil.getMemberByMemberId(memberId);
+        Member currentMember = memberUtil.getCurrentMember();
+
+        Slice<Order> orders = orderRepository.findByMember(targetMember, pageable);
+
+        Slice<OrderResponse> orderResponses = orders.map(OrderResponse::from);
+        return SliceResponse.from(orderResponses);
     }
 }

--- a/src/main/java/shop/sgmarket/sgmarketbackend/order/domain/repository/OrderRepository.java
+++ b/src/main/java/shop/sgmarket/sgmarketbackend/order/domain/repository/OrderRepository.java
@@ -2,9 +2,12 @@ package shop.sgmarket.sgmarketbackend.order.domain.repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import shop.sgmarket.sgmarketbackend.member.domain.Member;
 import shop.sgmarket.sgmarketbackend.order.domain.Order;
 
 @Repository
@@ -25,5 +28,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
         where o.orderUid = :orderUid
     """)
     Optional<Order> findOrderAndPayment(String orderUid);
+
+    Slice<Order> findByMember(Member member, Pageable pageable);
 }
 

--- a/src/main/resources/application-imp.yml
+++ b/src/main/resources/application-imp.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    activate:
+      on-profile: imp
+
+imp:
+  api:
+    client-code: ${IMP_CLIENT_CODE}
+    key: ${IMP_KEY}
+    secret-key: ${IMP_SECRET_KEY}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요.
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #105 

<br/>

### ☀️ 어떻게 이슈를 해결했나요?

---

- 특정 회원의 구매 목록 조회 기능 추가
- 

<br/>

### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to retrieve a paginated list of orders for a specific member.
  - Introduced a new configuration file for the "imp" profile, allowing external configuration of API credentials.

- **Documentation**
  - Enhanced API documentation to include details for the new member orders retrieval endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->